### PR TITLE
Add Python-to-DAG parser and utilities

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,27 @@
+import argparse
+import json
+
+import parser as dsl_parser
+import pseudo as pseudo_module
+import export_svg
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Convert Python function plan to DAG")
+    ap.add_argument("file", help="Python file containing the plan function")
+    ap.add_argument("--func", default="plan", help="Function name to parse")
+    ap.add_argument("--svg", action="store_true", help="Also export plan.svg")
+    args = ap.parse_args()
+
+    plan = dsl_parser.parse_file(args.file, function_name=args.func)
+    with open("plan.json", "w", encoding="utf-8") as f:
+        json.dump(plan, f, indent=2)
+    pseudo_code = pseudo_module.generate(plan)
+    with open("plan.pseudo", "w", encoding="utf-8") as f:
+        f.write(pseudo_code)
+    if args.svg:
+        export_svg.export(plan, filename="plan.svg")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/export_svg.py
+++ b/export_svg.py
@@ -1,0 +1,23 @@
+from typing import Dict, Any
+
+try:
+    from graphviz import Digraph
+except Exception:  # pragma: no cover
+    Digraph = None  # type: ignore
+
+
+def export(plan: Dict[str, Any], filename: str = "plan.svg") -> str:
+    """Export the plan as an SVG using graphviz."""
+    if Digraph is None:
+        raise RuntimeError("graphviz is required for SVG export")
+    graph = Digraph(format="svg")
+    for op in plan.get("ops", []):
+        graph.node(op["id"], label=op["op"])
+        for dep in op.get("deps", []):
+            graph.edge(dep, op["id"])
+    for out in plan.get("outputs", []):
+        out_id = f"out:{out['as']}"
+        graph.node(out_id, label=out['as'], shape="note")
+        graph.edge(out["from"], out_id)
+    graph.render(filename, cleanup=True)
+    return filename

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,137 @@
+import ast
+import json
+import re
+from typing import Any, Dict, List
+
+VALID_NAME_RE = re.compile(r'^[a-z_][a-z0-9_]{0,63}$')
+
+
+class DSLParseError(Exception):
+    """Raised when the mini-DSL constraints are violated."""
+
+
+def _literal(node: ast.AST) -> Any:
+    """Return a Python literal from an AST node or raise DSLParseError."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [_literal(elt) for elt in node.elts]
+    if isinstance(node, ast.Dict):
+        return {_literal(k): _literal(v) for k, v in zip(node.keys, node.values)}
+    raise DSLParseError("Keyword argument values must be JSON-serialisable literals")
+
+
+def _get_call_name(func: ast.AST) -> str:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        parts: List[str] = []
+        while isinstance(func, ast.Attribute):
+            parts.append(func.attr)
+            func = func.value
+        if isinstance(func, ast.Name):
+            parts.append(func.id)
+            return ".".join(reversed(parts))
+    raise DSLParseError("Only simple or attribute names are allowed for operations")
+
+
+def parse(source: str, function_name: str = "plan") -> Dict[str, Any]:
+    if len(source) > 20_000:
+        raise DSLParseError("Source too large")
+    module = ast.parse(source)
+    fn = None
+    for node in module.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
+            fn = node
+            break
+    if fn is None:
+        raise DSLParseError(f"Function {function_name!r} not found")
+
+    defined: set[str] = set()
+    ops: List[Dict[str, Any]] = []
+    outputs: List[Dict[str, str]] = []
+    settings: Dict[str, Any] = {}
+
+    for stmt in fn.body:
+        if isinstance(stmt, ast.Assign):
+            if len(stmt.targets) != 1 or not isinstance(stmt.targets[0], ast.Name):
+                raise DSLParseError("Assignment targets must be simple names")
+            var_name = stmt.targets[0].id
+            if not VALID_NAME_RE.match(var_name):
+                raise DSLParseError(f"Invalid variable name: {var_name}")
+            if var_name in defined:
+                raise DSLParseError(f"Duplicate variable name: {var_name}")
+
+            value = stmt.value
+            if isinstance(value, ast.Await):
+                value = value.value
+            if not isinstance(value, ast.Call):
+                raise DSLParseError("Right hand side must be a call")
+            op_name = _get_call_name(value.func)
+
+            deps: List[str] = []
+            for arg in value.args:
+                if not isinstance(arg, ast.Name):
+                    raise DSLParseError("Positional args must be variable names")
+                if arg.id not in defined:
+                    raise DSLParseError(f"Undefined dependency: {arg.id}")
+                deps.append(arg.id)
+
+            kwargs: Dict[str, Any] = {}
+            for kw in value.keywords:
+                if kw.arg is None:
+                    raise DSLParseError("**kwargs are not allowed")
+                kwargs[kw.arg] = _literal(kw.value)
+
+            ops.append({"id": var_name, "op": op_name, "deps": deps, "args": kwargs})
+            defined.add(var_name)
+
+        elif isinstance(stmt, ast.Expr):
+            call = stmt.value
+            if isinstance(call, ast.Await):
+                call = call.value
+            if not isinstance(call, ast.Call):
+                raise DSLParseError("Only call expressions allowed at top level")
+            name = _get_call_name(call.func)
+            if name == "settings":
+                for kw in call.keywords:
+                    if kw.arg is None:
+                        raise DSLParseError("settings does not accept **kwargs")
+                    settings[kw.arg] = _literal(kw.value)
+                if call.args:
+                    raise DSLParseError("settings only accepts keyword literals")
+            elif name == "output":
+                if len(call.args) != 1 or not isinstance(call.args[0], ast.Name):
+                    raise DSLParseError("output requires a single variable name argument")
+                var = call.args[0].id
+                if var not in defined:
+                    raise DSLParseError(f"Undefined output variable: {var}")
+                filename = None
+                for kw in call.keywords:
+                    if kw.arg in {"as", "as_"}:
+                        filename = _literal(kw.value)
+                    else:
+                        raise DSLParseError("output only accepts 'as' keyword")
+                if filename is None or not isinstance(filename, str):
+                    raise DSLParseError("output requires as=\"filename\"")
+                outputs.append({"from": var, "as": filename})
+            else:
+                raise DSLParseError("Only settings() and output() calls allowed as expressions")
+        else:
+            raise DSLParseError("Only assignments and expression calls are allowed in function body")
+
+    if not outputs:
+        raise DSLParseError("At least one output() call required")
+    if len(ops) > 200:
+        raise DSLParseError("Too many operations")
+
+    plan: Dict[str, Any] = {"version": 1, "ops": ops, "outputs": outputs}
+    if settings:
+        plan["settings"] = settings
+    return plan
+
+
+def parse_file(filename: str, function_name: str = "plan") -> Dict[str, Any]:
+    with open(filename, "r", encoding="utf-8") as f:
+        src = f.read()
+    return parse(src, function_name=function_name)

--- a/pseudo.py
+++ b/pseudo.py
@@ -1,0 +1,27 @@
+import json
+from typing import Dict, Any
+
+
+def generate(plan: Dict[str, Any]) -> str:
+    """Generate human readable pseudo-code from a plan dict."""
+    lines = []
+    settings = plan.get("settings")
+    if settings:
+        args = ", ".join(f"{k}={json.dumps(v)}" for k, v in settings.items())
+        lines.append(f"settings({args})")
+        lines.append("")
+    for op in plan.get("ops", []):
+        deps = op.get("deps", [])
+        kw = op.get("args", {})
+        parts = []
+        if deps:
+            parts.extend(deps)
+        if kw:
+            parts.extend(f"{k}={json.dumps(v)}" for k, v in kw.items())
+        arg_str = ", ".join(parts)
+        lines.append(f"{op['id']} = {op['op']}({arg_str})")
+    if plan.get("ops"):
+        lines.append("")
+    for out in plan.get("outputs", []):
+        lines.append(f"output({out['from']}, as={json.dumps(out['as'])})")
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import parser
+
+
+def parse_src(code: str):
+    return parser.parse(code)
+
+
+def test_accepts_async_await_and_attribute_calls():
+    code = '''
+async def plan():
+    a = await AGENTX.op1()
+    b = await AGENTX.op2(a, k=1)
+    output(b, as_="out.txt")
+'''
+    plan = parse_src(code)
+    assert len(plan["ops"]) == 2
+    assert len(plan["outputs"]) == 1
+    assert plan["ops"][-1]["id"] == "b"
+
+
+def test_rejects_fstrings_and_subscripts():
+    code = '''
+def plan():
+    a = AGENT.op()
+    s = f"val {a['k']}"
+    output(a, as_="o.txt")
+'''
+    with pytest.raises(Exception):
+        parse_src(code)
+
+
+def test_rejects_imports_loops_if():
+    code = '''
+def plan():
+    import os
+'''
+    with pytest.raises(Exception):
+        parse_src(code)
+
+
+def test_rejects_undefined_dep():
+    code = '''
+def plan():
+    b = AGENT.op(a)
+    output(b, as_="o.txt")
+'''
+    with pytest.raises(Exception):
+        parse_src(code)
+
+
+def test_requires_output():
+    code = '''
+def plan():
+    a = AGENT.op()
+'''
+    with pytest.raises(Exception):
+        parse_src(code)


### PR DESCRIPTION
## Summary
- Implement parser for the mini-DSL with async/await stripping, attribute calls, and validation
- Add pseudo-code and SVG exporters plus CLI
- Include tests covering valid and invalid plans

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8f894a8148321a1dca3f1211ad3ff