### PR TITLE
Capture awaited calls in parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -146,4 +146,6 @@ async def flow():
     plan = parser.parse(code)
     comp = next(op for op in plan["ops"] if op["op"].startswith("COMP."))
     assert len(comp["deps"]) == 1
+    field_op = next(op for op in plan["ops"] if op["op"] == "AG5.op3")
+    assert field_op.get("await") is True
 


### PR DESCRIPTION
## Summary
- track whether call expressions are awaited and record it on emitted ops
- handle awaited calls in dict assignments and statement parsing
- test that awaited operations like AG5.op3 are marked with `await`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc9d0eb4e08321a1b4db7312a5906b