### PR TITLE
Add break node support

### DIFF
--- a/py2dag/cli.py
+++ b/py2dag/cli.py
@@ -143,6 +143,8 @@ def _to_nodes_edges(plan: dict) -> dict:
             return "forloop_item"
         if op_name == "PHI":
             return "phi"
+        if op_name == "CTRL.break":
+            return "break"
         if op_name.startswith("COMP."):
             comp = op_name.split(".", 1)[1]
             return f"comp:{comp}"

--- a/py2dag/parser.py
+++ b/py2dag/parser.py
@@ -581,7 +581,11 @@ def parse(source: str, function_name: Optional[str] = None) -> Dict[str, Any]:
                         "args": {"var": var},
                     })
                 return None
-            elif isinstance(stmt, (ast.Pass, ast.Continue, ast.Break)):
+            elif isinstance(stmt, ast.Break):
+                ssa = _ssa_new("break")
+                ops.append({"id": ssa, "op": "CTRL.break", "deps": [], "args": {}})
+                return None
+            elif isinstance(stmt, (ast.Pass, ast.Continue)):
                 return None
             else:
                 raise DSLParseError("Only assignments, control flow, settings/output calls, and return are allowed in function body")


### PR DESCRIPTION
## Summary
- emit CTRL.break operations for `break` statements
- classify CTRL.break as `break` type in CLI graph output
- test for break node type output

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bca1ed44948321b48e207042ec5f9a