### PR TITLE
feat: orient exports vertically with colored nodes

### DIFF
--- a/plan.html
+++ b/plan.html
@@ -8,7 +8,7 @@
     body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Arial, sans-serif; margin: 0; padding: 0; }
     header { padding: 10px 16px; background: #111; color: #eee; font-size: 14px; }
     #container { padding: 12px; }
-    svg { width: 100%; height: 80vh; border-top: 1px solid #ddd; }
+    svg { width: 100%; height: 80vh; border: 1px solid #ddd; margin: 10px; }
     .node rect { stroke: #666; fill: #fff; rx: 4; ry: 4; }
     .node.note rect { fill: #fff8dc; }
     .edgePath path { stroke: #333; fill: none; stroke-width: 1.2px; }
@@ -23,6 +23,7 @@
   </div>
   <script>
     const plan = {"version": 2, "function": "flow", "ops": [{"id": "a_1", "op": "AG1.src", "deps": [], "args": {}, "dep_labels": []}, {"id": "xs_1", "op": "AG1.op", "deps": ["a_1"], "args": {"param2": 42}, "dep_labels": ["param1"], "await": true}, {"id": "crossing_info_1", "op": "CONST.value", "deps": [], "args": {"value": null}}, {"id": "iter_1", "op": "ITER.eval", "deps": ["xs_1"], "args": {"expr": "xs", "kind": "for", "target": "x"}}, {"id": "x_1@loop1", "op": "ITER.item", "deps": ["iter_1"], "args": {"target": "x"}}, {"id": "call_1@loop1", "op": "AG3.proc", "deps": ["x_1@loop1"], "args": {}, "dep_labels": [""]}, {"id": "crossed_1@loop1", "op": "AG4.op2", "deps": ["x_1@loop1"], "args": {}, "dep_labels": [""], "await": true}, {"id": "cond_1@loop1", "op": "COND.eval", "deps": ["crossed_1@loop1"], "args": {"expr": "not crossed", "kind": "if"}}, {"id": "approx_time_1@loop1", "op": "AG3.op", "deps": ["x_1@loop1"], "args": {}, "dep_labels": [""], "await": true}, {"id": "data_1@loop1", "op": "AG4.op", "deps": ["approx_time_1@loop1"], "args": {}, "dep_labels": [""], "await": true}, {"id": "lat_1@loop1", "op": "GET.item", "deps": ["data_1@loop1"], "args": {"key": "sensor_lat"}}, {"id": "lon_1@loop1", "op": "GET.item", "deps": ["data_1@loop1"], "args": {"key": "sensor_lon"}}, {"id": "call_2@loop1", "op": "AG4.proc", "deps": ["approx_time_1@loop1"], "args": {}, "dep_labels": [""]}, {"id": "crossing_info_field_1@loop1", "op": "AG5.op3", "deps": ["approx_time_1@loop1"], "args": {}, "dep_labels": [""], "await": true}, {"id": "crossing_info_2@loop1", "op": "PACK.dict", "deps": ["approx_time_1@loop1", "crossing_info_field_1@loop1", "x_1@loop1", "lat_1@loop1", "lon_1@loop1"], "args": {"keys": ["approx_time", "details", "item", "lat", "lon"]}}, {"id": "break_1@loop1", "op": "CTRL.break", "deps": [], "args": {}}, {"id": "foreach_1", "op": "COMP.foreach", "deps": ["xs_1"], "args": {"target": "x"}}, {"id": "crossing_info_2", "op": "PHI", "deps": ["crossing_info_1", "crossing_info_2@loop1"], "args": {"var": "crossing_info"}}], "outputs": [{"from": "crossing_info_2", "as": "return"}]};
+    const COLOR_MAP = {"AG1.src": "lightcoral", "AG1.op": "salmon", "CONST.value": "lightcoral", "ITER.eval": "turquoise", "ITER.item": "lightcoral", "AG3.proc": "sandybrown", "AG4.op2": "plum", "COND.eval": "orchid", "AG3.op": "gold", "AG4.op": "gold", "GET.item": "plum", "AG4.proc": "orchid", "AG5.op3": "lightcoral", "PACK.dict": "orchid", "CTRL.break": "mediumseagreen", "COMP.foreach": "orchid", "PHI": "mediumseagreen", "output": "plum"};
 
     function showMessage(msg) {
       const el = document.getElementById('container');
@@ -37,7 +38,7 @@
     } else {
       try {
         const g = new dagreD3.graphlib.Graph({ multigraph: true })
-          .setGraph({ rankdir: 'LR', nodesep: 30, ranksep: 40 });
+          .setGraph({ rankdir: 'TB', nodesep: 30, ranksep: 40 });
         // Ensure edges have an object for labels/attrs to avoid TypeErrors
         g.setDefaultEdgeLabel(() => ({}));
 
@@ -56,13 +57,15 @@
             label = 'PHI' + (op.args && op.args.var ? ` (${op.args.var})` : '');
             klass = 'note';
           }
-          g.setNode(op.id, { label, class: klass, padding: 8 });
+          const color = COLOR_MAP[op.op] || '#fff';
+          g.setNode(op.id, { label, class: klass, padding: 8, style: 'fill: ' + color });
         });
 
         // Add output nodes and edges from source to output
         (plan.outputs || []).forEach(out => {
           const outId = `out:${out.as}`;
-          g.setNode(outId, { label: out.as, class: 'note', padding: 8 });
+          const ocolor = COLOR_MAP['output'] || '#fff';
+          g.setNode(outId, { label: out.as, class: 'note', padding: 8, style: 'fill: ' + ocolor });
           g.setEdge(out.from, outId);
         });
 

--- a/py2dag/colors.py
+++ b/py2dag/colors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import hashlib
+
+CRAYON_COLORS = [
+    "cornflowerblue",
+    "lightcoral",
+    "gold",
+    "mediumseagreen",
+    "orchid",
+    "sandybrown",
+    "plum",
+    "turquoise",
+    "khaki",
+    "salmon",
+]
+
+
+def color_for(name: str) -> str:
+    """Return a pseudo-random but stable color for a given name.
+
+    Picks from CRAYON_COLORS using a SHA256 hash for determinism so the same
+    node type is colored consistently across exports.
+    """
+    h = hashlib.sha256(name.encode("utf-8")).hexdigest()
+    idx = int(h, 16) % len(CRAYON_COLORS)
+    return CRAYON_COLORS[idx]
+

--- a/py2dag/export_svg.py
+++ b/py2dag/export_svg.py
@@ -1,5 +1,7 @@
 from typing import Dict, Any
 
+from .colors import color_for
+
 try:
     from graphviz import Digraph
 except Exception:  # pragma: no cover
@@ -22,6 +24,9 @@ def export(plan: Dict[str, Any], filename: str = "plan.svg") -> str:
         raise RuntimeError("Python package 'graphviz' is required for SVG export")
 
     graph = Digraph(format="svg")
+    # Top-down layout with a bounding box around the graph
+    graph.attr(rankdir="TB")
+    graph.attr("graph", margin="0.2", pad="0.3", color="#bbb")
 
     # Index ops for edge label decisions
     ops = list(plan.get("ops", []))
@@ -29,7 +34,12 @@ def export(plan: Dict[str, Any], filename: str = "plan.svg") -> str:
 
     # Nodes
     for op in ops:
-        graph.node(op["id"], label=op["op"])
+        graph.node(
+            op["id"],
+            label=op["op"],
+            style="filled",
+            fillcolor=color_for(op["op"]),
+        )
 
     # Dependency edges with labels showing data/control
     for op in ops:
@@ -66,7 +76,13 @@ def export(plan: Dict[str, Any], filename: str = "plan.svg") -> str:
             graph.edge(dep, op["id"], label=label or dep)
     for out in plan.get("outputs", []):
         out_id = f"out:{out['as']}"
-        graph.node(out_id, label=out['as'], shape="note")
+        graph.node(
+            out_id,
+            label=out['as'],
+            shape="note",
+            style="filled",
+            fillcolor=color_for("output"),
+        )
         graph.edge(out["from"], out_id)
 
     try:


### PR DESCRIPTION
## Summary
- render both Graphviz and Dagre exports top-down instead of left-right
- add SVG margins/borders and color nodes using stable crayon palette
- provide reusable color helper for consistent node colors

## Testing
- `PYTHONPATH=. pytest -q`
- `python - <<'PY'
from py2dag import parser, export_dagre
code = open('examples/sample2.py').read()
plan = parser.parse(code)
export_dagre.export(plan, filename='plan.html')
PY`
- `python - <<'PY'
from py2dag import parser, export_svg
code = open('examples/sample2.py').read()
plan = parser.parse(code)
try:
    export_svg.export(plan, filename='plan.svg')
    print('svg generated')
except RuntimeError as e:
    print('skip svg', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bcb74f016c832189112d0b1131e80e