### PR TITLE
Add DAG JSON export to tests

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,13 @@
+import sys
+from pathlib import Path
+
 import pytest
+
+# Ensure package root is importable when running tests directly
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from py2dag import parser, cli
 
 


### PR DESCRIPTION
## Summary
- ensure tests can import local package by adjusting `sys.path`
- write DAG JSON alongside HTML and SVG artifacts in export tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb8aa91e083219348692214de6bce