### PR TITLE
chore: copy source files in run output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ run:
 	for file in examples/sample1.py examples/sample2.py; do \
 		base=$$(basename $$file .py); \
 		$(POETRY) run py2dag $$file --html; \
+		cp $$file .out/$$base.py; \
 		mv plan.json .out/$$base.json; \
 		mv plan.pseudo .out/$$base.pseudocode; \
 		mv plan.html .out/$$base.html; \


### PR DESCRIPTION
## Summary
- copy each example's `.py` file into `.out` during `make run`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc33d1fe0832199352fa88b3841f3