### PR TITLE
Skip docstrings in parser function body iteration

### DIFF
--- a/py2dag/parser.py
+++ b/py2dag/parser.py
@@ -603,7 +603,10 @@ def parse(source: str, function_name: Optional[str] = None) -> Dict[str, Any]:
                 raise DSLParseError("Only assignments, control flow, settings/output calls, and return are allowed in function body")
 
         # Parse body sequentially; still require a resulting output
-        for i, stmt in enumerate(fn.body):  # type: ignore[attr-defined]
+        body = list(getattr(fn, "body", []))  # type: ignore[attr-defined]
+        if body and isinstance(body[0], ast.Expr) and isinstance(getattr(body[0], "value", None), ast.Constant) and isinstance(getattr(body[0].value, "value", None), str):  # type: ignore[attr-defined]
+            body = body[1:]
+        for stmt in body:
             _parse_stmt(stmt)
 
         if not outputs:


### PR DESCRIPTION
## Summary
- ensure function docstrings are ignored when parsing so top-level DSL statements remain valid

## Testing
- `pytest tests/test_parser.py::test_break_node_type -vv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1520cc6c8321926be19a17e1ff4c