### PR TITLE
Handle undefined names in value dependency collection

### DIFF
--- a/py2dag/parser.py
+++ b/py2dag/parser.py
@@ -108,7 +108,7 @@ def parse(source: str, function_name: Optional[str] = None) -> Dict[str, Any]:
             deps: List[str] = []
             for n in ast.walk(node):
                 if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load):
-                    if n.id not in callees and n.id not in deps:
+                    if n.id not in callees and n.id not in deps and n.id in latest:
                         deps.append(n.id)
             return deps
 


### PR DESCRIPTION
## Summary
- Ignore undefined identifiers when collecting expression dependencies in the parser to allow loops over external variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf277b7f8c8321a93213b21ce3c139