### PR TITLE
Allow return of dynamic dict values

### DIFF
--- a/py2dag/parser.py
+++ b/py2dag/parser.py
@@ -509,15 +509,19 @@ def parse(source: str, function_name: Optional[str] = None) -> Dict[str, Any]:
                         })
                         returned_var = const_id
                 elif isinstance(stmt.value, (ast.Constant, ast.List, ast.Tuple, ast.Dict)):
-                    lit = _literal(stmt.value)
-                    const_id = _ssa_new("return_value")
-                    ops.append({
-                        "id": const_id,
-                        "op": "CONST.value",
-                        "deps": [],
-                        "args": {"value": lit},
-                    })
-                    returned_var = const_id
+                    try:
+                        lit = _literal(stmt.value)
+                    except DSLParseError:
+                        returned_var = _emit_assign_from_literal_or_pack("return_value", stmt.value)
+                    else:
+                        const_id = _ssa_new("return_value")
+                        ops.append({
+                            "id": const_id,
+                            "op": "CONST.value",
+                            "deps": [],
+                            "args": {"value": lit},
+                        })
+                        returned_var = const_id
                 else:
                     raise DSLParseError("return must return a variable name or literal")
                 return None


### PR DESCRIPTION
## Summary
- support return statements that construct dictionaries (or other aggregates) with variable, call, or awaited values
- ensure parser assigns PACK nodes when return value isn't a plain literal

## Testing
- `pytest tests/test_parser.py::test_return -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31838a3d083219947d57586a9baae