### PR TITLE
Improve unsupported RHS error reporting

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -404,6 +404,20 @@ async def flow():
     plan = parser.parse(code)
     assert plan["function"] == "flow"
 
+
+def test_unsupported_rhs_reports_expression():
+    code = '''
+def flow():
+    truck_ids = []
+    bus_ids = []
+    candidate_ids = truck_ids + bus_ids
+    return {}
+'''
+    with pytest.raises(parser.DSLParseError) as excinfo:
+        parser.parse(code)
+    assert "truck_ids + bus_ids" in str(excinfo.value)
+
+
 def test_basic():
     code = '''
 async def flow():


### PR DESCRIPTION
## Summary
- include the offending expression in the unsupported right hand side error
- re-raise the specific parser error when only one function candidate exists
- add a regression test covering the improved error message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc68454f348321bec7583aa62f7314