### PR TITLE
Add workflow to release patch versions from GitHub

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -1,0 +1,49 @@
+name: Patch release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: "Branch to release from"
+        required: false
+        default: main
+
+permissions:
+  contents: write
+
+jobs:
+  patch-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.release_branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          python scripts/version_utils.py bump
+          VERSION=$(python scripts/version_utils.py print)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore(release): v${{ steps.bump.outputs.version }}"
+          git tag v${{ steps.bump.outputs.version }}
+
+      - name: Push commit and tag
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git push origin HEAD
+          git push origin "refs/tags/v$VERSION"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ make patch        # bumps version, commits, and tags vX.Y.Z
 make release      # pushes commits and tags to GitHub (triggers publish)
 ```
 
+Or trigger the "Patch release" GitHub Action from the Actions tab to bump, commit, tag, and push directly from GitHub.
+
 Or push tags manually:
 
 ```


### PR DESCRIPTION
## Summary
- add a workflow_dispatch GitHub Action that bumps the patch version, commits, tags, and pushes using the repository token
- document the ability to trigger patch releases directly from GitHub alongside the existing make targets

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cc6c4119a8832186b16b1c2b653bc5