### PR TITLE
Ensure patch releases publish to PyPI

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -41,6 +41,20 @@ jobs:
           git commit -m "chore(release): v${{ steps.bump.outputs.version }}"
           git tag v${{ steps.bump.outputs.version }}
 
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build sdist and wheel
+        run: |
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
       - name: Push commit and tag
         env:
           VERSION: ${{ steps.bump.outputs.version }}


### PR DESCRIPTION
## Summary
- install build tooling and build the distribution inside the patch release workflow
- publish the newly built artifacts to PyPI before pushing the release commit and tag

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc6dce975083218f23cab16600d0db