### PR TITLE
Support expression assignments in parser

### DIFF
--- a/py2dag/cli.py
+++ b/py2dag/cli.py
@@ -91,6 +91,8 @@ def _to_nodes_edges(plan: dict) -> dict:
             if tgt:
                 return f"for {tgt} in {expr}"
             return f"iter {expr}"
+        if op_name == "EXPR.eval":
+            return str(args.get("expr"))
         if op_name == "ITER.item":
             return str(args.get("target") or "item")
         if op_name == "PHI":
@@ -160,6 +162,8 @@ def _to_nodes_edges(plan: dict) -> dict:
         if op_name.startswith("COMP."):
             comp = op_name.split(".", 1)[1]
             return f"comp:{comp}"
+        if op_name == "EXPR.eval":
+            return "expr"
         # Default: treat as a call/tool node
         return "call"
 


### PR DESCRIPTION
## Summary
- emit `EXPR.eval` nodes when assignments use arithmetic or comparison expressions so parsing succeeds
- teach the CLI node rendering helpers to display and classify `EXPR.eval` nodes

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc73d4f8fc83219fe34ecccd340c0c